### PR TITLE
fix: fix deep_map_mut() can not pass doctest

### DIFF
--- a/hw/hw06/hw06.py
+++ b/hw/hw06/hw06.py
@@ -134,10 +134,12 @@ def deep_map_mut(func, lnk):
     >>> print(link1)
     <9 <16> 25 36>
     """
-    while lnk is not None:
+    assert isinstance(lnk, Link)
+    while lnk is not Link.empty:
         if isinstance(lnk.first, Link):
             deep_map_mut(func, lnk.first)
-        lnk.first = func(lnk.first)
+        else:
+            lnk.first = func(lnk.first)
         lnk = lnk.rest
 
 


### PR DESCRIPTION
fix `deep_map_mut()` can not pass `python ok -q deep_map_mut --local`

```sh
=====================================================================
Assignment: Homework 6
OK, version v1.18.1
=====================================================================

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Running tests

---------------------------------------------------------------------
Doctests for deep_map_mut

>>> from hw06 import *
>>> link1 = Link(3, Link(Link(4), Link(5, Link(6))))
>>> print(link1)
<3 <4> 5 6>
>>> # Disallow the use of making new Links before calling deep_map_mut
>>> Link.__init__, hold = lambda *args: print("Do not create any new Links."), Link.__init__
>>> try:
...     deep_map_mut(lambda x: x * x, link1)
... finally:
...     Link.__init__ = hold
Traceback (most recent call last):
  File "D:\Workbench\CS61A\hw\hw06\hw06.py", line 139, in deep_map_mut
    deep_map_mut(func, lnk.first)
  File "D:\Workbench\CS61A\hw\hw06\hw06.py", line 138, in deep_map_mut
    if isinstance(lnk.first, Link):
                  ^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'first'

# Error: expected

# but got
#     Traceback (most recent call last):
#       ...
#     AttributeError: 'tuple' object has no attribute 'first'

---------------------------------------------------------------------
Test summary
    0 test cases passed before encountering first failed test case

Cannot backup when running ok with --local.
```